### PR TITLE
Fix #9: Handle TXT Records correctly

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
-          "version": "2.14.0"
+          "revision": "213eb6887e526e0dfac526a2eae559a1893ebbac",
+          "version": "2.36.0"
         }
       }
     ]

--- a/Sources/DNSClient/DNSDecoder.swift
+++ b/Sources/DNSClient/DNSDecoder.swift
@@ -60,12 +60,16 @@ final class DNSDecoder: ChannelInboundHandler {
         }
 
         do {
+            let answers = try resourceRecords(count: header.answerCount)
+            let authorities = try resourceRecords(count: header.authorityCount)
+            let additionalData = try resourceRecords(count: header.additionalRecordCount)
+            
             let message = Message(
                 header: header,
                 questions: questions,
-                answers: try resourceRecords(count: header.answerCount),
-                authorities: try resourceRecords(count: header.authorityCount),
-                additionalData: try resourceRecords(count: header.additionalRecordCount)
+                answers: answers,
+                authorities: authorities,
+                additionalData: additionalData
             )
 
             guard let query = messageCache[header.id] else {

--- a/Sources/DNSClient/Messages/Message.swift
+++ b/Sources/DNSClient/Messages/Message.swift
@@ -120,7 +120,7 @@ public struct ARecord: DNSResource {
     public var stringAddress: String {
         return withUnsafeBytes(of: address) { buffer in
             let buffer = buffer.bindMemory(to: UInt8.self)
-            return "\(buffer[0]).\(buffer[1]).\(buffer[2]).\(buffer[3])"
+            return "\(buffer[3]).\(buffer[2]).\(buffer[1]).\(buffer[0])"
         }
     }
 

--- a/Sources/DNSClient/Messages/Message.swift
+++ b/Sources/DNSClient/Messages/Message.swift
@@ -81,28 +81,37 @@ public enum Record {
 }
 
 public struct TXTRecord: DNSResource {
-    public let text: String
-    public let key: String
-    public let value: String
     
-    init?(text: String) {
-        let parts = text.split(separator: "=")
-        
-        if parts.count != 2 {
-            return nil
-        }
-        
-        self.text = text
-        self.key = String(parts[0])
-        self.value = String(parts[1])
+    public let values: [String: String]
+    
+    init(values: [String: String]) {
+        self.values = values
     }
 
     public static func read(from buffer: inout ByteBuffer, length: Int) -> TXTRecord? {
-        guard let string = buffer.readString(length: length) else {
-            return nil
+        var currentIndex = 0
+        var components: [String: String] = [:]
+        
+        while currentIndex < length {
+            guard let componentLenght = buffer.readInteger(endianness: .big, as: UInt8.self) else {
+                return nil
+            }
+            
+            guard let componentString = buffer.readString(length: Int(componentLenght)) else {
+                return nil
+            }
+            
+            let parts = componentString.split(separator: "=")
+            
+            if parts.count != 2 {
+                return nil
+            }
+            
+            components[String(parts[0])] = String(parts[1])
+            currentIndex += (Int(componentLenght) + 1)
         }
         
-        return TXTRecord(text: string)
+        return TXTRecord(values: components)
     }
 }
 

--- a/Tests/DNSClientTests/DNSClientTests.swift
+++ b/Tests/DNSClientTests/DNSClientTests.swift
@@ -35,6 +35,23 @@ final class DNSClientTests: XCTestCase {
         let answers = try dnsClient.getSRVRecords(from: "_mongodb._tcp.ok0-xkvc1.mongodb.net").wait()
         XCTAssertGreaterThanOrEqual(answers.count, 1, "The returned answers should be greater than or equal to 1")
     }
+    
+    func testSRVRecordsAsyncRequest() throws {
+        let expectation = self.expectation(description: "getSRVRecords")
+
+        dnsClient.getSRVRecords(from: "_mongodb._tcp.ok0-xkvc1.mongodb.net")
+        .whenComplete { (result) in
+            switch result {
+            case .failure(let error):
+                XCTFail("\(error)")
+            case .success(let answers):
+                print(answers)
+                XCTAssertGreaterThanOrEqual(answers.count, 1, "The returned answers should be greater than or equal to 1")
+            }
+            expectation.fulfill()
+        }
+        self.waitForExpectations(timeout: 5, handler: nil)
+    }
 
     static var allTests = [
         ("testAQuery", testAQuery),


### PR DESCRIPTION
As stated at https://datatracker.ietf.org/doc/html/rfc6763#section-6.1 , TXT Record payload can be composed by multiple  components (key/value pairs) that are preceded by a 8-bit integer indicating the length of the key/value pair.

An example of TXT Record is ( https://datatracker.ietf.org/doc/html/rfc6763#section-6.6 ):

| 0x09 | key=value | 0x08 | paper=A4 | 0x07 | passreq |
--- | --- | --- | --- | --- | --- |

This pull request fixes #9 . Also fixes IP Address to string conversion, since the IP Address returned was reversed and includes #8 .