### PR TITLE
WIP: Update /etc/resolv.conf parsing

### DIFF
--- a/Sources/DNSClient/ResolvConf/ConfigParser.swift
+++ b/Sources/DNSClient/ResolvConf/ConfigParser.swift
@@ -1,6 +1,6 @@
 import NIO
 
-fileprivate let nameserverPrefix = "nameserver "
+fileprivate let nameserverPrefix = "nameserver"
 
 struct ResolvConf {
     let nameservers: [SocketAddress]
@@ -15,7 +15,8 @@ struct ResolvConf {
             }
 
             line.removeFirst(nameserverPrefix.count)
-            try nameservers.append(SocketAddress(ipAddress: String(line), port: 53))
+            let ipAddress = String(line.drop(while: { $0 == " " || $0 == "\t" }))
+            try nameservers.append(SocketAddress(ipAddress: ipAddress, port: 53))
         }
 
         self.nameservers = nameservers

--- a/Sources/DNSClient/ResolvConf/ConfigParser.swift
+++ b/Sources/DNSClient/ResolvConf/ConfigParser.swift
@@ -15,8 +15,13 @@ struct ResolvConf {
             }
 
             line.removeFirst(nameserverPrefix.count)
-            let ipAddress = String(line.drop(while: { $0 == " " || $0 == "\t" }))
-            try nameservers.append(SocketAddress(ipAddress: ipAddress, port: 53))
+            let ipAddress = line.drop(while: { $0 == " " || $0 == "\t" })
+            guard ipAddress.startIndex != line.startIndex else {
+                // There should be at least one separator character
+                continue nextLine
+            }
+
+            try nameservers.append(SocketAddress(ipAddress: String(ipAddress), port: 53))
         }
 
         self.nameservers = nameservers


### PR DESCRIPTION
I found a case on a Linux machine where in `/etc/resolv.conf` the `nameserver` field was separated with a tab character from its IP address value instead of a whitespace, which caused the default DNS server to not be detected.

This commit changes the following:
- Accept tab characters in addition to whitespace characters
- Accept more than a single tab/whitespace character separating `nameserver` and the IP address in case some systems would define it this way. I'm not really sure about this but I also couldn't find any specification indicating exactly what the rules are for the format of `/etc/resolv.conf` and I supposed it's not unreasonable to think this could sometimes happen.

Please let me know what you think! 🙂 