### PR TITLE
Add rawValues property to TXTRecord

### DIFF
--- a/Sources/DNSClient/Messages/Message.swift
+++ b/Sources/DNSClient/Messages/Message.swift
@@ -82,37 +82,42 @@ public enum Record {
 }
 
 public struct TXTRecord: DNSResource {
-    
     public let values: [String: String]
+    public let rawValues: [String]
     
-    init(values: [String: String]) {
+    init(values: [String: String], rawValues: [String]) {
         self.values = values
+        self.rawValues = rawValues
     }
 
     public static func read(from buffer: inout ByteBuffer, length: Int) -> TXTRecord? {
         var currentIndex = 0
         var components: [String: String] = [:]
+        var rawValues: [String] = []
         
         while currentIndex < length {
             guard let componentLenght = buffer.readInteger(endianness: .big, as: UInt8.self) else {
                 return nil
             }
+
+            currentIndex += (Int(componentLenght) + 1)
             
             guard let componentString = buffer.readString(length: Int(componentLenght)) else {
                 return nil
             }
+
+            rawValues.append(componentString)
             
             let parts = componentString.split(separator: "=")
             
             if parts.count != 2 {
-                return nil
+                continue
             }
             
             components[String(parts[0])] = String(parts[1])
-            currentIndex += (Int(componentLenght) + 1)
         }
         
-        return TXTRecord(values: components)
+        return TXTRecord(values: components, rawValues: rawValues)
     }
 }
 


### PR DESCRIPTION
In some cases, the TXT record fields don't follow the key=value format and cannot be parsed by using the `=` separator.
I propose adding a `rawValues` property to `TXTRecord` that will store all raws values while the `values` property will contain the parsed key/values like it does today.
Do you think it is a correct approach?