### PR TITLE
Don't restore buffer value in UInt16FrameDecoder

### DIFF
--- a/Sources/DNSClient/DNSEncoder.swift
+++ b/Sources/DNSClient/DNSEncoder.swift
@@ -21,15 +21,12 @@ final class UInt16FrameDecoder: ByteToMessageDecoder {
     typealias InboundOut = ByteBuffer
     
     func decode(context: ChannelHandlerContext, buffer: inout ByteBuffer) throws -> DecodingState {
-        var readBuffer = buffer
         guard
             let size: UInt16 = buffer.readInteger(),
             let slice = buffer.readSlice(length: Int(size))
         else {
             return .needMoreData
         }
-        
-        buffer = readBuffer
         context.fireChannelRead(wrapInboundOut(slice))
         return .continue
     }


### PR DESCRIPTION
It seems that when restoring the previous value, NIO will keep wanting calling the UInt16FrameDecoder methods infinitely, causing some promises to not be succeeded anymore.