### PR TITLE
add link to swiftinit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Async DNS resolution, with all the DNS features you need!
 
 [Join our Discord](https://discord.gg/H6799jh) for any questions and friendly banter.
 
+[Browse our API reference](https://swiftinit.org/reference/niodns).
+
 ### Installation 💥
 
 Add the package:


### PR DESCRIPTION
adds a link to the swiftinit docs at https://swiftinit.org/reference/niodns